### PR TITLE
Add public path to linked resources on scss files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,12 @@ module.exports = (env, options) => ({
         use: [
           options.mode !== "production"
             ? "style-loader"
-            : MiniCssExtractPlugin.loader,
+            : {
+                loader: MiniCssExtractPlugin.loader,
+                options: {
+                  publicPath: "../"
+                }
+              },
           "css-loader",
           {
             loader: 'postcss-loader', 


### PR DESCRIPTION
Fix wrong paths to linked resources when build on production.

Resources must be linked like this.

`background-image: url("../assets/img/hero.png")`